### PR TITLE
Real .NET Core platform support

### DIFF
--- a/SQLitePCL.pretty/packages.config
+++ b/SQLitePCL.pretty/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="SQLitePCLRaw.core" version="1.1.0" targetFramework="portable45-net45+win8+wp8+wpa81" />
+  <package id="SQLitePCLRaw.core" version="1.1.0" targetFramework="portable45-net45+netcore45+win8+wp8+wpa81" />
 </packages>


### PR DESCRIPTION
SQLitePCL.pretty had SQLitePCLRaw.core dependency targeted w/o netcore45, that's why it was impossible to install it in .NET Core, even w/ correct .nuspec (netcore45 already presented). This commit fix it, but it'll be a good idea to add support for other profiles supported by SQLitePCLRaw.core too (sl15 and so on).